### PR TITLE
Reestructurar MySQL DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+MySQLConnector.py

--- a/DATABASE/agercore.sql
+++ b/DATABASE/agercore.sql
@@ -48,77 +48,84 @@ INSERT INTO `area` (`id`, `name`, `level`, `areaType`) VALUES
 -- Estructura de tabla para la tabla `characters`
 --
 
-CREATE TABLE `characters` (
-  `id` int(11) NOT NULL,
-  `idClass` int(11) NOT NULL,
-  `name` varchar(50) NOT NULL,
-  `idUser` int(11) NOT NULL,
-  `level` int(1) NOT NULL,
-  `exp` bigint(20) NOT NULL,
-  `expLimit` bigint(20) NOT NULL,
-  `mapLocation` int(12) NOT NULL DEFAULT 5,
-  `mapPositionX` float NOT NULL,
-  `mapPositionY` float NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
+CREATE TABLE IF NOT EXISTS `characters` (
+	`char_id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`account_id` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+	`char_num` TINYINT(1) NOT NULL DEFAULT '0',
+	`name` VARCHAR(50) NOT NULL COLLATE 'utf8_general_ci',
+	`class_id` INT(11) NOT NULL,
+	`level` SMALLINT(6) UNSIGNED NOT NULL DEFAULT '1',
+	`exp` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+	`expLimit` BIGINT(20) NOT NULL,
+	`last_map` INT(12) NOT NULL DEFAULT '5',
+	`last_x` FLOAT NOT NULL,
+	`last_y` FLOAT NOT NULL,
+	`online` TINYINT(2) NOT NULL DEFAULT '0',
+	`sex` ENUM('M','F') NOT NULL COLLATE 'utf8_general_ci',
+	PRIMARY KEY (`char_id`) USING BTREE,
+	UNIQUE INDEX `name` (`name`) USING BTREE,
+	INDEX `account_id` (`account_id`) USING BTREE
+)
+ENGINE=InnoDB AUTO_INCREMENT=150000;
 --
 -- Volcado de datos para la tabla `characters`
 --
 
-INSERT INTO `characters` (`id`, `idClass`, `name`, `idUser`, `level`, `exp`, `expLimit`, `mapLocation`, `mapPositionX`, `mapPositionY`) VALUES
-(1, 3, 'Warrior', 4, 5, 0, 5, 1, 0, 0),
-(2, 1, 'Baba', 1, 7, 1, 5, 1, 0, 0),
-(4, 2, 'test character', 1, 3, 0, 5, 1, 0, 0),
-(5, 3, 'Pepito', 5, 1, 0, 5, 1, 0, 0);
+INSERT INTO `characters` (`account_id`, `char_id`, `char_num`, `name`, `class_id`, `level`, `exp`, `expLimit`, `last_map`, `last_x`, `last_y`, `online`, `sex`) VALUES
+(2000000, 150000, 0, 'Warrior', 3, 5, 0, 5, 1, 0, 0, 0, 'M'),
+(2000000, 150001, 0, 'Baba', 1, 7, 1, 5, 1, 0, 0, 0, 'M'),
+(2000001, 150002, 0, 'test character', 2, 3, 0, 5, 1, 0, 0, 0, 'M'),
+(2000002, 150003, 0, 'Pepito', 3, 1, 0, 5, 1, 0, 0, 0, 'M');
+
 
 -- --------------------------------------------------------
 
 --
--- Estructura de tabla para la tabla `charclass`
+-- Estructura de tabla para la tabla `class_db`
 --
 
-CREATE TABLE `charclass` (
-  `id` int(11) NOT NULL,
+CREATE TABLE IF NOT EXISTS `class_db` (
+  `class_id` int(11) NOT NULL,
   `name` varchar(50) NOT NULL,
   `intelligence` int(11) NOT NULL,
   `dexterity` int(11) NOT NULL,
   `strength` int(11) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT  AUTO_INCREMENT=0;
 
 --
--- Volcado de datos para la tabla `charclass`
+-- Volcado de datos para la tabla `class_db`
 --
 
-INSERT INTO `charclass` (`id`, `name`, `intelligence`, `dexterity`, `strength`) VALUES
-(1, 'warrior', 5, 10, 15),
-(2, 'rogue', 10, 15, 5),
-(3, 'mage', 15, 5, 10);
+INSERT INTO `class_db` (`id`, `name`, `intelligence`, `dexterity`, `strength`) VALUES
+(0, 'warrior', 5, 10, 15),
+(1, 'rogue', 10, 15, 5),
+(2, 'mage', 15, 5, 10);
 
 -- --------------------------------------------------------
 
 --
--- Estructura de tabla para la tabla `users`
+-- Estructura de tabla para la tabla `login`
 --
 
-CREATE TABLE `users` (
-  `id` int(11) NOT NULL,
-  `username` varchar(100) NOT NULL,
-  `password` varchar(200) NOT NULL,
-  `email` varchar(200) NOT NULL,
-  `selectedCharacterId` int(11) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE IF NOT EXISTS `login` (
+  `account_id` int(11) unsigned NOT NULL auto_increment,
+  `username` varchar(23) NOT NULL default '',
+  `userpass` varchar(32) NOT NULL default '',
+  `email` varchar(39) NOT NULL default '',
+  `character_slots` tinyint(3) unsigned NOT NULL default '0',
+) ENGINE=InnoDB AUTO_INCREMENT=2000000; 
 
 --
--- Volcado de datos para la tabla `users`
+-- Volcado de datos para la tabla `login`
 --
 
-INSERT INTO `users` (`id`, `username`, `password`, `email`, `selectedCharacterId`) VALUES
-(1, 'test', '123456', '', 0),
-(4, 'test2', '123456', 'test@mail.com', 0),
-(5, 'test3', '123456', '', 0);
+INSERT INTO `login` (`account_id`, `username`, `userpass`, `email`, `character_slots`) VALUES
+(2000000, 'test', '123456', '', 0),
+(2000001, 'test2', '123456', 'test@mail.com', 0),
+(2000002, 'test3', '123456', '', 0);
 
 --
--- Índices para tablas volcadas
+-- Ýndices para tablas volcadas
 --
 
 --
@@ -132,18 +139,18 @@ ALTER TABLE `area`
 --
 ALTER TABLE `characters`
   ADD PRIMARY KEY (`id`),
-  ADD KEY `idUser` (`idUser`);
+  ADD KEY `account_id` (`account_id`);
 
 --
--- Indices de la tabla `charclass`
+-- Indices de la tabla `class_db`
 --
-ALTER TABLE `charclass`
+ALTER TABLE `class_db`
   ADD PRIMARY KEY (`id`);
 
 --
--- Indices de la tabla `users`
+-- Indices de la tabla `login`
 --
-ALTER TABLE `users`
+ALTER TABLE `login`
   ADD PRIMARY KEY (`id`);
 
 --
@@ -160,19 +167,19 @@ ALTER TABLE `area`
 -- AUTO_INCREMENT de la tabla `characters`
 --
 ALTER TABLE `characters`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+  MODIFY `char_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
--- AUTO_INCREMENT de la tabla `charclass`
+-- AUTO_INCREMENT de la tabla `class_db`
 --
-ALTER TABLE `charclass`
+ALTER TABLE `class_db`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 --
--- AUTO_INCREMENT de la tabla `users`
+-- AUTO_INCREMENT de la tabla `login`
 --
-ALTER TABLE `users`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+ALTER TABLE `login`
+  MODIFY `account_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/MySQLConnector.py
+++ b/MySQLConnector.py
@@ -3,8 +3,8 @@ import mysql.connector
 class MySQLConnector:
     def __init__(self):
         self.host = "localhost"
-        self.user = "root"
-        self.password = ""
+        self.user = "ragnarok"
+        self.password = "ragnarok"
         self.database = "agercore"
         self.conn = None
 

--- a/Server.py
+++ b/Server.py
@@ -39,7 +39,7 @@ async def handle_client(reader, writer):
             del connected_clients[client_socket]
 
 async def start_server():
-    server_address = ('localhost', 12345)
+    server_address = ('localhost', 6900)
 
     server = await asyncio.start_server(
         handle_client, *server_address, reuse_address=True)

--- a/core/Player.py
+++ b/core/Player.py
@@ -11,7 +11,7 @@ class Player:
     self.level = 0
     self.exp = 0
     self.expLimit = 0
-    self.idClass = 0
+    self.class_id = 0
 
     self.mapId = 0
     self.mapPositionX = 0
@@ -31,15 +31,15 @@ class Player:
      self.mapPositionX = X
      self.mapPositionY = Y
 
-  def CharacterEnter(self,characterId,name,level,exp,expLimit,idClass):
+  def CharacterEnter(self,characterId,name,level,exp,expLimit,class_id):
     self.characterId = characterId
     self.name = name
     self.level = level
     self.exp = exp
     self.expLimit = expLimit
-    self.idClass = idClass
+    self.class_id = class_id
     self.isCharacterEntered=True
-    #print( f"{self.characterId} {self.name} {self.level} {self.exp} {self.expLimit} {self.idClass}"  )
+    #print( f"{self.characterId} {self.name} {self.level} {self.exp} {self.expLimit} {self.class_id}"  )
 
     
 

--- a/networkCalls/auth/CallLogin.py
+++ b/networkCalls/auth/CallLogin.py
@@ -21,9 +21,9 @@ class CallLogin(ComType):
         connector.connect()
         
         user = remove_special_characters(received_data["username"]).lower()
-        password = remove_special_characters(received_data["password"])
+        userpass = remove_special_characters(received_data["userpass"])
 
-        query = "SELECT * FROM users WHERE username ='"+user+"' AND password='"+password+"' LIMIT 0,1"
+        query = "SELECT * FROM login WHERE username ='"+user+"' AND userpass='"+userpass+"' LIMIT 0,1"
         results = connector.execute_query(query)
         if results:
             for row in results:
@@ -35,7 +35,7 @@ class CallLogin(ComType):
                 response = "MSG"+CALL_DELIMITER+"LOGINOK"+CALL_DELIMITER+"OK"
                 player.client_socket.sendall(response.encode())
         else:
-            #print("wroing user or password")
+            #print("wroing user or userpass")
             response = "ERROR"+CALL_DELIMITER+"LOGIN"+CALL_DELIMITER+"ERR"
             player.client_socket.sendall(response.encode())
 

--- a/networkCalls/auth/CallRegister.py
+++ b/networkCalls/auth/CallRegister.py
@@ -15,7 +15,7 @@ from interfaces.ComType import ComType
 def check_account_exists(conn, account_name):
         try:
             cursor = conn.cursor()
-            query = "SELECT COUNT(*) FROM users WHERE username ='"+account_name+"'"
+            query = "SELECT COUNT(*) FROM login WHERE username ='"+account_name+"'"
             cursor.execute(query)
             result = cursor.fetchone()[0]
             cursor.close()
@@ -25,11 +25,11 @@ def check_account_exists(conn, account_name):
             print("Error check_account_exists:", err)
             return False
 
-def create_account(conn, username, password, email):
+def create_account(conn, username, userpass, email):
         try:
             cursor = conn.cursor()
-            query = "INSERT INTO users (username,password,email) VALUES(%s,%s,%s)"
-            values = (username, password, email)
+            query = "INSERT INTO login (username,userpass,email) VALUES(%s,%s,%s)"
+            values = (username, userpass, email)
             cursor.execute(query, values)
             conn.commit()
             cursor.close()
@@ -48,7 +48,7 @@ class CallRegister(ComType):
         connector.connect()
         
         user = remove_special_characters(received_data["username"]).lower()
-        password = remove_special_characters(received_data["password"])
+        userpass = remove_special_characters(received_data["userpass"])
 
         if(is_valid_email(received_data["mail"])):
             mail = received_data["mail"]
@@ -59,7 +59,7 @@ class CallRegister(ComType):
             return
 
         if not check_account_exists(connector.conn, user):
-            create_account(connector.conn,user,password,mail)
+            create_account(connector.conn,user,userpass,mail)
             response = "MSG"+CALL_DELIMITER+"REGISTEROK"+CALL_DELIMITER+"OK"
             player.client_socket.sendall(response.encode())
         else:

--- a/networkCalls/character/CallCharacterCreate.py
+++ b/networkCalls/character/CallCharacterCreate.py
@@ -26,11 +26,11 @@ def check_character_exists(conn, account_name):
             print("Error check_account_exists:", err)
             return False
 
-def create_character(conn, name, idClass, idUser):
+def create_character(conn, name, class_id, account_id):
         try:
             cursor = conn.cursor()
-            query = "INSERT INTO characters (name,idClass,idUser) VALUES(%s,%s,%s)"
-            values = (name, idClass, idUser)
+            query = "INSERT INTO characters (name,class_id,account_id) VALUES(%s,%s,%s)"
+            values = (name, class_id, account_id)
             cursor.execute(query, values)
             conn.commit()
             cursor.close()
@@ -51,13 +51,13 @@ class CallCharacterCreate(ComType):
         received_data = json.loads(jsonData)
 
         dataName =   remove_special_characters(received_data['name'])
-        idClass = int(received_data['idClass'])
+        class_id = int(received_data['class_id'])
         connector = MySQLConnector()
 
         connector.connect()
 
         if not check_character_exists(connector.conn, dataName):
-            create_character(connector.conn,dataName,idClass, player.accountId)
+            create_character(connector.conn,dataName,class_id, player.accountId)
             response = "MSG"+CALL_DELIMITER+"CREATECHARACTEROK"+CALL_DELIMITER+"OK"
             player.client_socket.sendall(response.encode())
         else:

--- a/networkCalls/character/CallCharacterEnter.py
+++ b/networkCalls/character/CallCharacterEnter.py
@@ -30,12 +30,12 @@ class CallCharacterEnter(ComType):
 
         characterId = int(received_data['characterId'])
 
-        query = "SELECT id,name,level,exp,expLimit, idClass, mapLocation, mapPositionX, mapPositionY FROM characters WHERE idUser  ='"+format(player.accountId)+"' AND id="+format(characterId)+" LIMIT 0,1"
+        query = "SELECT id,name,level,exp,expLimit, class_id, mapLocation, mapPositionX, mapPositionY FROM characters WHERE account_id  ='"+format(player.accountId)+"' AND id="+format(characterId)+" LIMIT 0,1"
         results = connector.execute_query(query)
         response=""
         if results:
             for row in results:
-                character = '{"id": "'+format(row[0])+'", "name": "'+format(row[1])+'", "level":  "'+format(row[2])+'","exp":  "'+format(row[3])+'","expLimit":  "'+format(row[4])+'", "idClass": "'+format(row[5])+'", "mapLocation": "'+format(row[6])+'", "mapPositionX": "'+format(row[7])+'", "mapPositionY": "'+format(row[8])+'"}'
+                character = '{"id": "'+format(row[0])+'", "name": "'+format(row[1])+'", "level":  "'+format(row[2])+'","exp":  "'+format(row[3])+'","expLimit":  "'+format(row[4])+'", "class_id": "'+format(row[5])+'", "mapLocation": "'+format(row[6])+'", "mapPositionX": "'+format(row[7])+'", "mapPositionY": "'+format(row[8])+'"}'
                 response += "MSG"+CALL_DELIMITER+"CHARACTER"+CALL_DELIMITER+"ENTER"+CALL_DELIMITER+""+character+CALL_MULTYLINE
                 #check if you have already a character loged
                 for client in connected_clients:

--- a/networkCalls/character/CallCharactersList.py
+++ b/networkCalls/character/CallCharactersList.py
@@ -26,12 +26,12 @@ class CallCharactersList(ComType):
 
         connector.connect()
 
-        query = "SELECT id,name,level,idClass FROM characters WHERE idUser  ='"+format(player.accountId)+"'"
+        query = "SELECT id,name,level,class_id FROM characters WHERE account_id  ='"+format(player.accountId)+"'"
         results = connector.execute_query(query)
         response=""
         if results:
             for row in results:
-                character = '{"id": "'+format(row[0])+'", "name": "'+format(row[1])+'", "level":  "'+format(row[2])+'", "idClass": "'+format(row[3])+'"}'
+                character = '{"id": "'+format(row[0])+'", "name": "'+format(row[1])+'", "level":  "'+format(row[2])+'", "class_id": "'+format(row[3])+'"}'
                 response += "MSG"+CALL_DELIMITER+"CHARACTER"+CALL_DELIMITER+"LIST"+CALL_DELIMITER+""+character+CALL_MULTYLINE
                 
             response += "MSG#CHARACTER"+CALL_DELIMITER+"SELECTED"+CALL_DELIMITER+format(player.selectedCharacterId)+CALL_MULTYLINE

--- a/networkCalls/world/CallEnterArea.py
+++ b/networkCalls/world/CallEnterArea.py
@@ -28,7 +28,7 @@ def get_all_players(areaId):
         response=""
         for socketId in connected_clients:
             if(connected_clients[socketId].mapId == areaId):
-                playerMsg = '{"id": "'+format(connected_clients[socketId].characterId)+'", "name": "'+connected_clients[socketId].name+'", "idClass":  "'+format(connected_clients[socketId].idClass)+'", "positionX":  "'+format(connected_clients[socketId].mapPositionX)+'", "positionY":  "'+format(connected_clients[socketId].mapPositionY)+'"}'
+                playerMsg = '{"id": "'+format(connected_clients[socketId].characterId)+'", "name": "'+connected_clients[socketId].name+'", "class_id":  "'+format(connected_clients[socketId].class_id)+'", "positionX":  "'+format(connected_clients[socketId].mapPositionX)+'", "positionY":  "'+format(connected_clients[socketId].mapPositionY)+'"}'
                 response += "WORLD"+CALL_DELIMITER+"PLAYER"+CALL_DELIMITER+""+playerMsg+CALL_MULTYLINE
         return response
 
@@ -36,7 +36,7 @@ def hey_im_here_to_players(player,areaId):
         response=""
         for socketId in connected_clients:
             if(connected_clients[socketId].mapId == areaId):
-                newPlayerMsg = '{"id": "'+format(player.characterId)+'", "name": "'+player.name+'", "idClass":  "'+format(player.idClass)+'", "positionX":  "'+format(player.mapPositionX)+'", "positionY":  "'+format(player.mapPositionY)+'"}'
+                newPlayerMsg = '{"id": "'+format(player.characterId)+'", "name": "'+player.name+'", "class_id":  "'+format(player.class_id)+'", "positionX":  "'+format(player.mapPositionX)+'", "positionY":  "'+format(player.mapPositionY)+'"}'
                 response = "WORLD"+CALL_DELIMITER+"PLAYER"+CALL_DELIMITER+""+newPlayerMsg+CALL_MULTYLINE
                 connected_clients[socketId].client_socket.sendall(response.encode())
 


### PR DESCRIPTION
Pensando en hacer una DB mas fácil de leer, hice algunos pequeños cambios en los nombres de las columnas y tablas.
Motivos detrás del cambio:
usar char_id y account_id es mucho mas facil a la hora de manejar datos de muchos jugadores y hacer filtrados y JOIN mucho mas intuitivos.
La razon por la cual char_id empieza en 150000 y account_id en 2000000, es para facilitar el tipo de ID con la que se trabaja.
el puerto 12345, lo cambie por 6900, ya que es un puerto muy usado para este tipo de tareas de comunicación.

Ojo también hice cambios en el client.